### PR TITLE
code change to avoid joint verse reading clash with mtag versenum

### DIFF
--- a/src/util/usfm_to_json.js
+++ b/src/util/usfm_to_json.js
@@ -26,6 +26,7 @@ module.exports = {
                 c = 0,
                 v = 0,
                 vnum = 0,
+                id = '',
                 usfmBibleBook = false,
                 validLineCount = 0,
                 id_prefix = options.lang + '_' + options.version + '_' + options.bibleName + '_';
@@ -48,6 +49,7 @@ module.exports = {
             } else if (splitLine[0] === '\\id') {
                 if (booksCodes.includes(splitLine[1].toUpperCase()))
                     usfmBibleBook = true;
+                    id = splitLine[1]
                 book._id = id_prefix + splitLine[1].toUpperCase();
             } else if (splitLine[0] === '\\c') {
                 book.chapters[parseInt(splitLine[1], 10) - 1] = {
@@ -107,10 +109,9 @@ module.exports = {
                 
             } else if (splitLine[0].match(new RegExp(/\\mt$/gm))) {
                 let cleanedStr = replaceMarkers(line);
-                let bookid = book._id.split(/_+/)
-                if (booksCodes.includes(bookid[2].toUpperCase())){
+                if (booksCodes.includes(id.toUpperCase())){
                     let userBookList = AutographaStore.translatedBookNames
-                    userBookList.splice(booksCodes.indexOf(bookid[2]), 1, cleanedStr)
+                    userBookList.splice(booksCodes.indexOf(id), 1, cleanedStr)
                 }
             } else if (splitLine[0].startsWith('\\s')) {
                 //Do nothing for section headers now.

--- a/src/util/usfm_to_json.js
+++ b/src/util/usfm_to_json.js
@@ -118,11 +118,13 @@ module.exports = {
                 // Do nothing here for now.
             } else if (splitLine[0].match(new RegExp(/\\m$/gm))) {
                 let cleanedStr = replaceMarkers(line);
-                cleanedStr = "\n" + cleanedStr;
-                book.chapters[c - 1].verses[vnum - 1].verse += ((cleanedStr.length === 0 ? '' : ' ') + cleanedStr);
+                cleanedStr = "\n" + cleanedStr
+                let verseIndex = book.chapters[c - 1].verses.findIndex(val => val.verse_number === vnum);
+                if(book.chapters[c - 1].verses[verseIndex].verse !== undefined)
+                book.chapters[c - 1].verses[verseIndex].verse += ((cleanedStr.length === 0 ? '' : ' ') + cleanedStr);
             } else if (splitLine[0].startsWith('\\r')) {
                 // Do nothing here for now.
-            } else if (c > 0 && vnum > 0) {
+            } else if (c > 0 && v > 0) {
                 var qflag = false;
                 if(line.match(new RegExp(/[\\q\n]/g))){
                     qflag = true
@@ -131,7 +133,8 @@ module.exports = {
                 if(qflag === false){
                     cleanedStr = "\n" + cleanedStr;
                 }
-                book.chapters[c - 1].verses[vnum - 1].verse += ((cleanedStr.length === 0 ? '' : ' ') + cleanedStr);
+                let verseIndex = book.chapters[c - 1].verses.findIndex(val => val.verse_number === vnum);
+                book.chapters[c - 1].verses[verseIndex].verse += ((cleanedStr.length === 0 ? '' : ' ') + cleanedStr);
             }
             
         });

--- a/src/util/usfm_to_json.js
+++ b/src/util/usfm_to_json.js
@@ -120,8 +120,9 @@ module.exports = {
                 let cleanedStr = replaceMarkers(line);
                 cleanedStr = "\n" + cleanedStr
                 let verseIndex = book.chapters[c - 1].verses.findIndex(val => val.verse_number === vnum);
-                if(book.chapters[c - 1].verses[verseIndex].verse !== undefined)
-                book.chapters[c - 1].verses[verseIndex].verse += ((cleanedStr.length === 0 ? '' : ' ') + cleanedStr);
+                if(book.chapters[c - 1].verses[verseIndex].verse !== undefined) {
+                    book.chapters[c - 1].verses[verseIndex].verse += ((cleanedStr.length === 0 ? '' : ' ') + cleanedStr);
+                }
             } else if (splitLine[0].startsWith('\\r')) {
                 // Do nothing here for now.
             } else if (c > 0 && v > 0) {


### PR DESCRIPTION
`vnum` was reading a versenumber from usfm tag for joint verse, but `v` was verse count. To read db we use `v` instead of `vnum` but for joint verse, it used to throw errror since verse count mismatch so we used `vnum`. But this use case clashes when the USFM only has a single verse in a chapter. 